### PR TITLE
Initial commit

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These members will be default reviewers for each repo
+* @IgorTodorovskiIBM @MikeFultonDev @DevonianTeuchter @HarithaIBM @v1gnesh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# Contributing
+
+## Issues
+
+Log an issue for any question or problem you might have. When in doubt, log an issue, and
+any additional policies about what to include will be provided in the responses. The only
+exception is security disclosures which should be sent privately.
+
+Committers may direct you to another repository, ask for additional clarifications, and
+add appropriate metadata before the issue is addressed.
+
+## Contributions
+
+Any change to resources in this repository must be through pull requests. This applies to all changes
+to documentation, code, binary files, etc.
+
+No pull request can be merged without being reviewed and approved.
+
+## Validate your changes
+
+Verify that the project is working by running `zopen build`.
+
+## Coding Guidelines
+
+When contributing your changes, please follow the following coding guidelines:
+* patches: patches should adhere to the coding guidelines from the original project repository. Make sure to add the original project's LICENSE file within the patches
+directory.
+* zopen framework files: (e.g. buildenv) - It is recommended that you follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+
+If you are generating a new project, we recommend that you use `zopen generate` to create the correct zopen file and directory structure.
+
+### Commit message
+
+A good commit message should describe what changed and why.
+
+It should:
+  * contain a short description of the change
+  * be entirely in lowercase with the exception of proper nouns, acronyms, and the words that refer to code, like function/variable names
+  * be prefixed with one of the following words:
+    * fix: bug fix
+    * hotfix: urgent bug fix
+    * feat: new or updated feature
+    * docs: documentation updates
+    * refactor: code refactoring (no functional change)
+    * perf: performance improvement
+    * test: tests and CI updates
+
+### Developer's Certificate of Origin 1.1
+
+<pre>
+By making a contribution to this project, I certify that:
+
+ (a) The contribution was created in whole or in part by me and I
+     have the right to submit it under the open source license
+     indicated in the file; or
+
+ (b) The contribution is based upon previous work that, to the best
+     of my knowledge, is covered under an appropriate open source
+     license and I have the right under that license to submit that
+     work with modifications, whether created in whole or in part
+     by me, under the same open source license (unless I am
+     permitted to submit under a different license), as indicated
+     in the file; or
+
+ (c) The contribution was provided directly to me by some other
+     person who certified (a), (b) or (c) and I have not modified
+     it.
+
+ (d) I understand and agree that this project and the contribution
+     are public and that a record of the contribution (including all
+     personal information I submit with it, including my sign-off) is
+     maintained indefinitely and may be redistributed consistent with
+     this project or the open source license(s) involved.
+</pre>
+DEVUSER:/data/work/ai/minjaport: >cat CODEOWNERS
+# These members will be default reviewers for each repo
+* @IgorTodorovskiIBM @MikeFultonDev @DevonianTeuchter @HarithaIBM @v1gnesh
+DEVUSER:/data/work/ai/minjaport: >cat CONTRIBUTING.md
+# Contributing
+
+## Issues
+
+Log an issue for any question or problem you might have. When in doubt, log an issue, and
+any additional policies about what to include will be provided in the responses. The only
+exception is security disclosures which should be sent privately.
+
+Committers may direct you to another repository, ask for additional clarifications, and
+add appropriate metadata before the issue is addressed.
+
+## Contributions
+
+Any change to resources in this repository must be through pull requests. This applies to all changes
+to documentation, code, binary files, etc.
+
+No pull request can be merged without being reviewed and approved.
+
+## Validate your changes
+
+Verify that the project is working by running `zopen build`.
+
+## Coding Guidelines
+
+When contributing your changes, please follow the following coding guidelines:
+* patches: patches should adhere to the coding guidelines from the original project repository. Make sure to add the original project's LICENSE file within the patches
+directory.
+* zopen framework files: (e.g. buildenv) - It is recommended that you follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+
+If you are generating a new project, we recommend that you use `zopen generate` to create the correct zopen file and directory structure.
+
+### Commit message
+
+A good commit message should describe what changed and why.
+
+It should:
+  * contain a short description of the change
+  * be entirely in lowercase with the exception of proper nouns, acronyms, and the words that refer to code, like function/variable names
+  * be prefixed with one of the following words:
+    * fix: bug fix
+    * hotfix: urgent bug fix
+    * feat: new or updated feature
+    * docs: documentation updates
+    * refactor: code refactoring (no functional change)
+    * perf: performance improvement
+    * test: tests and CI updates
+
+### Developer's Certificate of Origin 1.1
+
+<pre>
+By making a contribution to this project, I certify that:
+
+ (a) The contribution was created in whole or in part by me and I
+     have the right to submit it under the open source license
+     indicated in the file; or
+
+ (b) The contribution is based upon previous work that, to the best
+     of my knowledge, is covered under an appropriate open source
+     license and I have the right under that license to submit that
+     work with modifications, whether created in whole or in part
+     by me, under the same open source license (unless I am
+     permitted to submit under a different license), as indicated
+     in the file; or
+
+ (c) The contribution was provided directly to me by some other
+     person who certified (a), (b) or (c) and I have not modified
+     it.
+
+ (d) I understand and agree that this project and the contribution
+     are public and that a record of the contribution (including all
+     personal information I submit with it, including my sign-off) is
+     maintained indefinitely and may be redistributed consistent with
+     this project or the open source license(s) involved.
+</pre>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# minjaport
-Minja is a minimalistic reimplementation of the Jinja templating engine to integrate in/with C++ LLM projects (it's used in llama.cpp)
+[![Automatic version updates](https://github.com/zopencommunity/minjaport/actions/workflows/bump.yml/badge.svg)](https://github.com/ZOSOpenTools/minjaport/actions/workflows/bump.yml)
+
+# minja
+
+minja is a c++ templating engine for llm chat templates
+
+# Installation and Usage
+
+Use the zopen package manager ([QuickStart Guide](https://zopen.community/#/Guides/QuickStart)) to install:
+```bash
+zopen install minja
+```
+
+# Building from Source
+
+1. Clone the repository:
+```bash
+git clone https://github.com/zopencommunity/minjaport.git
+cd minjaport
+```
+2. Build using zopen:
+```bash
+zopen build -vv
+```
+
+See the [zopen porting guide](https://zopen.community/#/Guides/Porting) for more details.
+
+# Documentation
+
+
+# Troubleshooting
+
+# Contributing
+Contributions are welcome! Please follow the [zopen contribution guidelines](https://github.com/zopencommunity/meta/blob/main/CONTRIBUTING.md).

--- a/buildenv
+++ b/buildenv
@@ -1,0 +1,100 @@
+# Update bump details accordingly. Use bump check to confirm.
+# bump: minja-version /MINJA_VERSION="(.*)"/ https://github.com/google/minja.git|semver:*
+# MINJA_VERSION="V.R.M" # Specify a stable release
+# export ZOPEN_STABLE_TAG="v${MINJA_VERSION}"
+
+export ZOPEN_BUILD_LINE="DEV"
+
+export ZOPEN_STABLE_URL="https://github.com/google/minja.git"  # Specify the stable build URL (either git or tarball)
+export ZOPEN_STABLE_DEPS="zoslib make cmake grep check_python" # Specify the stable build dependencies.
+
+export ZOPEN_DEV_URL="https://github.com/google/minja.git"   # Specify the dev build URL
+export ZOPEN_DEV_DEPS="zoslib make cmake grep check_python"  # Specify the dev build dependencies
+
+export ZOPEN_CATEGORIES="ai"
+
+export ZOPEN_RUNTIME_DEPS=""
+
+## Runtime system prerequisites; supply the name of the system pre-requisties.
+## Current available prerequisites: zos24 zos25 zos31 procfs (see https://github.com/zopencommunity/meta/blob/main/include/prereq.sh for a current list)
+export ZOPEN_SYSTEM_PREREQ=""
+
+export ZOPEN_COMP="CLANG"
+
+export ZOPEN_EXTRA_CPPFLAGS="-D_POSIX_C_SOURCE=200112L"
+
+export ZOPEN_CONFIGURE="cmake" ## Configuration program to run (defaults to './configure')
+export ZOPEN_CONFIGURE_OPTS="-B ../build --install-prefix \"\$ZOPEN_INSTALL_DIR/\" -DPython_EXECUTABLE=\"\$PYTHON_VENV_PATH\" ."
+
+export ZOPEN_MAKE="cmake"      ## Build program to run (defaults to 'make')
+export ZOPEN_MAKE_OPTS=" --build ../build --parallel \$ZOPEN_NUM_JOBS --target all"
+
+export ZOPEN_INSTALL="cmake"
+export ZOPEN_INSTALL_OPTS=" --install ../build "
+
+export ZOPEN_CHECK="ctest"
+export ZOPEN_CHECK_OPTS="--test-dir ../build -j --output-on-failure"
+
+###
+### Required user-supplied functions
+###
+
+zopen_check_results()
+{
+  dir="$1"
+  pfx="$2"
+  chk="$1/$2_check.log"
+
+  if [[ -f "$chk" ]]; then
+    total=$(grep -cE "[0-9]+/[0-9]+ Test" "$chk")
+    failed=$(grep -cE "\*\*\*Failed" "$chk")
+    skipped=$(grep -cE "\*\*\*Skipped" "$chk")
+    passed=$((total-failed-skipped))
+  else
+    total=0
+    passed=0
+    failed=0
+    skipped=0
+  fi
+
+  # Echo the following information to gauge build health
+  echo "actualFailures:$failed"
+  echo "totalTests:$total"
+  echo "expectedFailures:0"
+  echo "expectedTotalTests:$total"
+}
+
+zopen_init()
+{
+if [ -n "*$VIRTUAL_ENV" ]; then
+    echo "Found $VIRTUAL_ENV..."
+    echo "Deactivating $VIRTUAL_ENV..."
+    deactivate
+fi
+
+if [ ! -d "minja_venv" ]; then
+    echo "Creating Python virtual environment"
+    python3 -m venv minja_venv
+fi
+
+. ./minja_venv/bin/activate
+
+if [ -f "requirements.txt" ]; then
+    echo "Installing all required packeges"
+    pip install -r requirements.txt
+fi
+
+export PYTHON_VENV_PATH="$(pwd)/minja_venv/bin/python"
+}
+
+zopen_get_version()
+{
+  # Modify to echo the version of your tool/library
+  # Rather than hardcoding the version, obtain the version by running the tool/library
+  echo "1.0.0"
+}
+
+zopen_post_install()
+{
+    deactivate
+}

--- a/cicd-dev.groovy
+++ b/cicd-dev.groovy
@@ -1,0 +1,14 @@
+node('linux')
+{
+  stage ('Poll') {
+    checkout([
+      $class: 'GitSCM',
+      branches: [[name: '*/main']],
+      doGenerateSubmoduleConfigurations: false,
+      extensions: [],
+      userRemoteConfigs: [[url: 'https://github.com/zopencommunity/minjaport.git']]])
+  }
+  stage('Build') {
+    build job: 'Port-Pipeline', parameters: [string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/zopencommunity/minjaport.git'), string(name: 'PORT_DESCRIPTION', value: 'minja is a c++ templating engine for llm chat templates' ), string(name: 'BUILD_LINE', value: 'DEV') ]
+  }
+}

--- a/cicd-stable.groovy
+++ b/cicd-stable.groovy
@@ -1,0 +1,14 @@
+node('linux')
+{
+  stage ('Poll') {
+    checkout([
+      $class: 'GitSCM',
+      branches: [[name: '*/main']],
+      doGenerateSubmoduleConfigurations: false,
+      extensions: [],
+      userRemoteConfigs: [[url: 'https://github.com/zopencommunity/minjaport.git']]])
+  }
+  stage('Build') {
+    build job: 'Port-Pipeline', parameters: [string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/zopencommunity/minjaport.git'), string(name: 'PORT_DESCRIPTION', value: 'minja is a c++ templating engine for llm chat templates' ), string(name: 'BUILD_LINE', value: 'STABLE') ]
+  }
+}


### PR DESCRIPTION
**Porting minja to z/OS**
---

**Summary of changes made**
---
- Generated buildenv
   - Additional z/OS dependencies - check_python .
   - _POSIX_C_SOURCE 200112L to use POSIX.1, POSIX.1a, POSIX.2 symbols [https://www.ibm.com/docs/en/zos/3.1.0?topic=files-feature-test-macros](url) .
   - zopen_init deactivates if any python virtual environment is active, creates a new python environment for each clean build names ‘minja_venv’, activates it and install all required python dependencies using pip.
   - Created python env ‘minja_venv’ is passed to configure stage.
   - Post installation created venv is activated.
   - Automating test case execution, summary of passed, failures test-cases.

- Tests summary
   - Pass rate: 99.2%. 2 failed out of 236 test-cases.
     
   <img width="662" height="122" alt="minja-tests" src="https://github.com/user-attachments/assets/454474fd-c161-4368-b3b9-76a56957f75e" />
